### PR TITLE
Add example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ nano .env
 # 3. Install Python dependencies
 pip install -r requirements.txt
 
-# 4. Edit configuration with your specific settings
+# 4. Copy example configuration
+cp config.example.yml config.yml
 nano config.yml
 
 # 5. Test connectivity

--- a/config.example.yml
+++ b/config.example.yml
@@ -1,0 +1,38 @@
+router:
+  host: 192.168.1.1
+  username: root
+  password: ${ROOTER_PASS}
+  ssh_port: 22
+  luci_port: 80
+  use_ssh: false
+
+jellyfin:
+  host: 192.168.1.243
+  port: 8096
+  api_key: ${JELLY_API}
+  use_https: false
+
+network:
+  internal_ranges:
+    - "192.168.1.0/24"
+    - "10.0.0.0/8"
+  test_mode: false
+  test_external_ranges:
+    - "203.0.113.0/24"
+
+bandwidth:
+  algorithm: equal_split
+  min_per_user: 2.0
+  max_per_user: 50.0
+  reserved_bandwidth: 10.0
+  total_upload_mbps: 100.0
+
+daemon:
+  update_interval: 30
+  log_level: INFO
+  log_file: jellydemon.log
+  log_max_size: 10MB
+  log_backup_count: 5
+  dry_run: false
+  backup_user_settings: true
+  pid_file: /tmp/jellydemon.pid


### PR DESCRIPTION
## Summary
- add sample `config.example.yml` demonstrating all keys
- update Quick Setup instructions to copy example config

## Testing
- `pytest -q` *(fails: fixture missing)*
- `python test_jellydemon.py --test config`
- `python test_jellydemon.py --test network`
- `python test_jellydemon.py --test openwrt` *(fails: connection)*
- `python test_jellydemon.py --test jellyfin` *(fails: connection)*
- `python test_jellydemon.py --test bandwidth`
- `python test_jellydemon.py --test integration` *(fails: connection)*

------
https://chatgpt.com/codex/tasks/task_e_684b5f65d9088326b953677800faad8d