### PR TITLE
Implement bandwidth usage smoothing

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -26,6 +26,8 @@ bandwidth:
   max_per_user: 50.0
   reserved_bandwidth: 10.0
   total_upload_mbps: 100.0
+  # Duration (in minutes) used to average bandwidth usage
+  spike_duration: 3
 
 daemon:
   update_interval: 30

--- a/modules/config.py
+++ b/modules/config.py
@@ -50,6 +50,7 @@ class BandwidthConfig:
     max_per_user: float = 50.0
     reserved_bandwidth: float = 10.0
     total_upload_mbps: float = 0
+    spike_duration: int = 3  # minutes to average usage over
 
 
 @dataclass
@@ -109,6 +110,8 @@ class Config:
         # Validate bandwidth config
         if self.bandwidth.min_per_user >= self.bandwidth.max_per_user:
             raise ValueError("min_per_user must be less than max_per_user")
+        if self.bandwidth.spike_duration <= 0:
+            raise ValueError("spike_duration must be greater than zero")
     
     def reload(self):
         """Reload configuration from file."""

--- a/test_smoothing.py
+++ b/test_smoothing.py
@@ -1,0 +1,24 @@
+import unittest
+from unittest.mock import patch
+
+from jellydemon import JellyDemon
+
+class BandwidthSmoothingTest(unittest.TestCase):
+    def test_rolling_average(self):
+        daemon = JellyDemon('config.example.yml')
+        daemon.config.bandwidth.spike_duration = 3
+
+        values = [10, 100, 10, 10]
+        times = [0, 10, 20, 200]
+
+        with patch.object(daemon.openwrt, 'get_bandwidth_usage', side_effect=values):
+            with patch('jellydemon.time.time', side_effect=times):
+                results = [daemon.get_current_bandwidth_usage() for _ in values]
+
+        self.assertAlmostEqual(results[0], 10.0, places=2)
+        self.assertAlmostEqual(results[1], 55.0, places=2)
+        self.assertAlmostEqual(results[2], 40.0, places=2)
+        self.assertAlmostEqual(results[3], 10.0, places=2)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add spike duration setting to `BandwidthConfig`
- document the setting in `config.example.yml`
- maintain history of bandwidth usage and calculate an averaged value
- add unit test covering the rolling average logic

## Testing
- `python -m unittest test_smoothing.py`
- `python test_jellydemon.py --config config.example.yml --test config`

------
https://chatgpt.com/codex/tasks/task_e_684b60a50d30832686ee3e6944519489