### PR TITLE
Add per-IP bandwidth tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ python jellydemon.py --dry-run
 4. **Configure your settings (config.yml):**
    - **Router settings**: OpenWRT router at 192.168.1.1 (username: root)
    - **Jellyfin settings**: Server at 192.168.1.243 (API key from .env)
-   - **Network ranges**: Configure your internal IP ranges  
+   - **jellyfin_ip**: IP of your Jellyfin server for traffic exclusion
+   - **Network ranges**: Configure your internal IP ranges
    - **Bandwidth settings**: Adjust limits and algorithm preferences
 
 5. **Get Jellyfin API Key:**
@@ -150,6 +151,7 @@ Key configuration options:
 
 - **Router settings**: 192.168.1.1 (username: root, password from .env)
 - **Jellyfin settings**: 192.168.1.243 (API key from .env)
+- **jellyfin_ip**: IP of your Jellyfin server for traffic exclusion
 - **Network ranges**: Define internal/external IP ranges
 - **Bandwidth algorithms**: Select calculation method
 - **Daemon settings**: Update intervals, logging level

--- a/config.example.yml
+++ b/config.example.yml
@@ -5,6 +5,7 @@ router:
   ssh_port: 22
   luci_port: 80
   use_ssh: false
+  jellyfin_ip: 192.168.1.243
 
 jellyfin:
   host: 192.168.1.243

--- a/jellydemon.py
+++ b/jellydemon.py
@@ -72,6 +72,13 @@ class JellyDemon:
         try:
             usage = self.openwrt.get_bandwidth_usage()
 
+            if self.config.router.jellyfin_ip:
+                jf_usage = self.openwrt.get_bandwidth_usage(self.config.router.jellyfin_ip)
+                usage = max(usage - jf_usage, 0)
+                self.logger.debug(
+                    f"Subtracting Jellyfin traffic {jf_usage:.2f} Mbps from total"
+                )
+
             now = time.time()
             self.bandwidth_history.append((now, usage))
 

--- a/modules/config.py
+++ b/modules/config.py
@@ -4,7 +4,7 @@ Configuration management for JellyDemon.
 
 import yaml
 from pathlib import Path
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 from dataclasses import dataclass
 
 
@@ -17,6 +17,7 @@ class RouterConfig:
     ssh_port: int = 22
     luci_port: int = 80
     use_ssh: bool = False
+    jellyfin_ip: Optional[str] = None
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- allow `OpenWRTClient` to read bandwidth for a single IP
- subtract Jellyfin server traffic from usage calculations
- support new `jellyfin_ip` config option
- document `jellyfin_ip` in README and example config

## Testing
- `python -m py_compile modules/openwrt_client.py modules/config.py jellydemon.py`
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: JELLY_API environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_684b620796e08326b24a7fa7cd457980