### PR TITLE
Add stream restart call on limit change

### DIFF
--- a/test_smoothing.py
+++ b/test_smoothing.py
@@ -7,6 +7,7 @@ class BandwidthSmoothingTest(unittest.TestCase):
     def test_rolling_average(self):
         daemon = JellyDemon('config.example.yml')
         daemon.config.bandwidth.spike_duration = 3
+        daemon.config.router.jellyfin_ip = None
 
         values = [10, 100, 10, 10]
         times = [0, 10, 20, 200]


### PR DESCRIPTION
## Summary
- implement `restart_stream` in `JellyfinClient`
- trigger stream restart in `JellyDemon.calculate_and_apply_limits`
- adjust smoothing test for jellyfin traffic subtraction

## Testing
- `pytest -q test_smoothing.py`

------
https://chatgpt.com/codex/tasks/task_e_684b648b85ac8326a0ea2cc0e6ff41c4