### PR TITLE
Add unit tests

### DIFF
--- a/tests/test_jellydemon_limits.py
+++ b/tests/test_jellydemon_limits.py
@@ -1,0 +1,28 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from jellydemon import JellyDemon
+
+class TestJellyDemonLimits(unittest.TestCase):
+    def test_restart_called_when_limit_changes(self):
+        daemon = JellyDemon('config.example.yml')
+        daemon.config.bandwidth.low_usage_threshold = 0
+        session = {
+            'Id': 's1',
+            'UserId': 'u1',
+            'NowPlayingItem': {'Id': 'i1', 'MediaSources': [{'Id': 'ms1'}]},
+            'PlayState': {'MediaSourceId': 'ms1', 'PositionTicks': 1}
+        }
+        external = {'u1': {'session_data': session}}
+
+        daemon.bandwidth_manager.calculate_limits = MagicMock(return_value={'u1': 5.0})
+        daemon.jellyfin.set_user_bandwidth_limit = MagicMock(return_value=True)
+        daemon.jellyfin.restart_stream = MagicMock(return_value=True)
+        daemon.openwrt.get_total_bandwidth = MagicMock(return_value=100.0)
+
+        daemon.calculate_and_apply_limits(external, current_usage=20.0)
+
+        daemon.jellyfin.set_user_bandwidth_limit.assert_called_with('u1', 5.0)
+        daemon.jellyfin.restart_stream.assert_called_with(session)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_jellyfin_client.py
+++ b/tests/test_jellyfin_client.py
@@ -1,0 +1,42 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from modules.jellyfin_client import JellyfinClient
+from modules.config import JellyfinConfig
+
+class TestJellyfinClient(unittest.TestCase):
+    def test_restart_stream_endpoints(self):
+        cfg = JellyfinConfig(host='localhost', port=8096, api_key='key')
+        client = JellyfinClient(cfg)
+        session = {
+            'Id': 'sess1',
+            'UserId': 'user1',
+            'NowPlayingItem': {
+                'Id': 'item1',
+                'MediaSources': [{'Id': 'ms1'}]
+            },
+            'PlayState': {'PositionTicks': 5}
+        }
+
+        with patch.object(client.session, 'post', side_effect=[MagicMock(status_code=204), MagicMock(status_code=204)]) as mock_post, \
+             patch('time.sleep'):
+            result = client.restart_stream(session)
+
+        self.assertTrue(result)
+        base = client.config.base_url
+        stop_call = mock_post.call_args_list[0]
+        resume_call = mock_post.call_args_list[1]
+        self.assertEqual(stop_call.args[0], f"{base}/Sessions/sess1/Playing/Stop")
+        resume_url = f"{base}/Sessions/sess1/Playing"
+        self.assertEqual(resume_call.args[0], resume_url)
+        params = resume_call.kwargs['params']
+        expected = {
+            'playCommand': 'PlayNow',
+            'itemIds': 'item1',
+            'startPositionTicks': 5,
+            'mediaSourceId': 'ms1',
+            'controllingUserId': 'user1'
+        }
+        self.assertEqual(params, expected)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_network_utils.py
+++ b/tests/test_network_utils.py
@@ -1,0 +1,27 @@
+import unittest
+from modules.network_utils import NetworkUtils
+from modules.config import NetworkConfig
+
+class TestNetworkUtils(unittest.TestCase):
+    def test_is_external_ip_normal_mode(self):
+        config = NetworkConfig(internal_ranges=['192.168.0.0/16', '10.0.0.0/8'])
+        utils = NetworkUtils(config)
+        self.assertFalse(utils.is_external_ip('192.168.1.1'))
+        self.assertFalse(utils.is_external_ip('10.20.30.40'))
+        self.assertTrue(utils.is_external_ip('172.16.0.1'))
+        self.assertTrue(utils.is_external_ip('8.8.8.8'))
+
+    def test_is_external_ip_test_mode(self):
+        config = NetworkConfig(
+            internal_ranges=['192.168.0.0/16'],
+            test_mode=True,
+            test_external_ranges=['203.0.113.0/24']
+        )
+        utils = NetworkUtils(config)
+        self.assertTrue(utils.is_external_ip('203.0.113.5'))
+        self.assertFalse(utils.is_external_ip('192.168.1.10'))
+        # In test mode IPs not in test_external_ranges are treated as internal
+        self.assertFalse(utils.is_external_ip('8.8.8.8'))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_smoothing.py
+++ b/tests/test_smoothing.py
@@ -1,0 +1,25 @@
+import unittest
+from unittest.mock import patch
+
+from jellydemon import JellyDemon
+
+class BandwidthSmoothingTest(unittest.TestCase):
+    def test_rolling_average(self):
+        daemon = JellyDemon('config.example.yml')
+        daemon.config.bandwidth.spike_duration = 3
+        daemon.config.router.jellyfin_ip = None
+
+        values = [10, 100, 10, 10]
+        times = [0, 10, 20, 200]
+
+        with patch.object(daemon.openwrt, 'get_bandwidth_usage', side_effect=values):
+            with patch('jellydemon.time.time', side_effect=times):
+                results = [daemon.get_current_bandwidth_usage() for _ in values]
+
+        self.assertAlmostEqual(results[0], 10.0, places=2)
+        self.assertAlmostEqual(results[1], 55.0, places=2)
+        self.assertAlmostEqual(results[2], 40.0, places=2)
+        self.assertAlmostEqual(results[3], 10.0, places=2)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add tests for NetworkUtils is_external_ip behavior
- test restart_stream's API calls
- test JellyDemon.calculate_and_apply_limits logic
- port smoothing test into tests/

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_684b72b95b848326bac4f37392b6792f