### PR TITLE
Support env vars in config

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -6,6 +6,7 @@ import yaml
 from pathlib import Path
 from typing import Dict, Any, List, Optional
 from dataclasses import dataclass
+import os
 
 
 @dataclass
@@ -82,7 +83,12 @@ class Config:
             raise FileNotFoundError(f"Configuration file not found: {self.config_path}")
         
         with open(self.config_path, 'r') as f:
-            config_data = yaml.safe_load(f)
+            raw_content = f.read()
+
+        # Expand any ${VAR} placeholders using environment variables
+        expanded_content = os.path.expandvars(raw_content)
+
+        config_data = yaml.safe_load(expanded_content)
         
         # Parse configuration sections
         self.router = RouterConfig(**config_data.get('router', {}))

--- a/tests/test_config_envvars.py
+++ b/tests/test_config_envvars.py
@@ -1,0 +1,35 @@
+import os
+import tempfile
+import unittest
+from modules.config import Config
+
+class TestConfigEnvVars(unittest.TestCase):
+    def test_env_var_substitution(self):
+        yaml_content = """
+router:
+  host: 192.168.1.1
+  username: root
+  password: ${TEST_ROUTER_PASS}
+jellyfin:
+  host: localhost
+  port: 8096
+  api_key: ${TEST_JELLY_API}
+network:
+  internal_ranges:
+    - "192.168.0.0/16"
+"""
+        with tempfile.NamedTemporaryFile('w+', delete=False) as tmp:
+            tmp.write(yaml_content)
+            tmp_path = tmp.name
+
+        os.environ['TEST_ROUTER_PASS'] = 'secret'
+        os.environ['TEST_JELLY_API'] = 'key'
+
+        cfg = Config(tmp_path)
+        self.assertEqual(cfg.router.password, 'secret')
+        self.assertEqual(cfg.jellyfin.api_key, 'key')
+
+        os.remove(tmp_path)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- expand `${VAR}` placeholders when loading config
- add a test verifying environment variables are substituted

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b7500d7ac83268b7f8d83e6d27334