### PR TITLE
Improve bandwidth limit logging and restart handling

### DIFF
--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -27,8 +27,7 @@ class TestDryRunMode(unittest.TestCase):
         daemon.jellyfin.set_user_bandwidth_limit.assert_not_called()
         daemon.jellyfin.restart_stream.assert_not_called()
         logs = '\n'.join(cm.output)
-        self.assertIn('[DRY RUN] Would change user u1 from 10.00 Mbps to 5.00 Mbps', logs)
-        self.assertIn('[DRY RUN] Would restart stream for user u1 (session s1)', logs)
+        self.assertIn('[DRY RUN] Would change user u1 from 10.00 Mbps to 5.00 Mbps (playing) - would restart stream (session s1)', logs)
 
     def test_shutdown_logs_restore(self):
         daemon = JellyDemon('config.example.yml')

--- a/tests/test_jellydemon_limits.py
+++ b/tests/test_jellydemon_limits.py
@@ -16,13 +16,13 @@ class TestJellyDemonLimits(unittest.TestCase):
 
         daemon.bandwidth_manager.calculate_limits = MagicMock(return_value={'u1': 5.0})
         daemon.jellyfin.set_user_bandwidth_limit = MagicMock(return_value=True)
-        daemon.jellyfin.restart_stream = MagicMock(return_value=True)
+        daemon.jellyfin.restart_stream = MagicMock()
         daemon.openwrt.get_total_bandwidth = MagicMock(return_value=100.0)
 
         daemon.calculate_and_apply_limits(external, current_usage=20.0)
 
-        daemon.jellyfin.set_user_bandwidth_limit.assert_called_with('u1', 5.0)
-        daemon.jellyfin.restart_stream.assert_called_with(session)
+        daemon.jellyfin.set_user_bandwidth_limit.assert_called_with('u1', 5.0, session)
+        daemon.jellyfin.restart_stream.assert_not_called()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- log current bitrate limit when fetching a policy
- log previous and new limits and playback state when applying limits
- restart streams from within `set_user_bandwidth_limit` and log together
- pass session data to the new API
- update dry-run messages
- extend unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b88e4981c832692850a819ca8d0d0